### PR TITLE
fix issue with centos 6.5 using script from util-linux-ng 2.17.2

### DIFF
--- a/src/TermRecord
+++ b/src/TermRecord
@@ -81,16 +81,17 @@ def runScript(command=None):
             timingfname = timingf.name 
             scriptfname = scriptf.name
 
-    CMD.append('-t%s' % timingfname)
+    CMD.append('-t')
 
     if command:
         CMD.append('-c')
         CMD.append(command)
 
     CMD.append(scriptfname)
-
-    proc = Popen(CMD)
+    ferr=open(timingfname,'a+')
+    proc = Popen(CMD, stderr=ferr)
     proc.wait()
+    ferr.close()
     return open(scriptfname, 'r'), open(timingfname, 'r') 
 
 def runTtyrec(command=None):


### PR DESCRIPTION
my version of script does not take an argument to -t
it only outputs timing info to stderr
so I work around this by redirecting stderr to the tmp file, timingfname
If some version of script is different, we'd have to detect that and use it accordingly.

this is my `pip list` version of TermRecord
TermRecord (1.1.3)
# uname -r

2.6.32-358.18.1.el6.x86_64
# cat /etc/issue

CentOS release 6.5 (Final)
Kernel \r on an \m
