### PR TITLE
brew without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TermRecord -o /tmp/session.html
 On Mac OS X you will need `ttyrec` as well:
 
 ```bash
-sudo brew install ttyrec
+brew install ttyrec
 ```
 
 If you want to run from source and not install:


### PR DESCRIPTION
with `sudo brew install ttyrec`, brew replies with the following:
Error: Cowardly refusing to 'sudo brew install'
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk.