### PR TITLE
Fix timing alignment due to codecs

### DIFF
--- a/bin/TermRecord
+++ b/bin/TermRecord
@@ -133,8 +133,12 @@ def scriptToJSON(scriptf, timing=None):
     with closing(scriptf):
         scriptf.readline() # ignore first header line from script file
         offset = 0
+        buf = ''
         for t in timing:
-            data = escapeString(scriptf.read(t[1]))
+            while (len(buf) < t[1]):
+                buf += scriptf.read(t[1])
+            data = escapeString(buf[:t[1]])
+            buf = buf[t[1]:]
             offset += t[0]
             ret.append((data, offset))
     return dumps(ret)


### PR DESCRIPTION
A file opened with copen can return more characters than requested
from a read() call.  This can result in the playback running fast.

To correct this, read into a buffer and then pull from the buffer
as directed by the timing file.